### PR TITLE
Add space_step() to step physics simulation manually

### DIFF
--- a/doc/classes/PhysicsServer2D.xml
+++ b/doc/classes/PhysicsServer2D.xml
@@ -950,11 +950,26 @@
 				Creates a 2D space in the physics server, and returns the [RID] that identifies it. A space contains bodies and areas, and controls the stepping of the physics simulation of the objects in it.
 			</description>
 		</method>
+		<method name="space_flush_queries" experimental="">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<description>
+				Flushes [param space]'s queries. It is necessary to call this method after calling [method space_step] with an active space from [code]_physics_process[/code]. Otherwise, call this method before calling [method space_step].
+			</description>
+		</method>
 		<method name="space_get_direct_state">
 			<return type="PhysicsDirectSpaceState2D" />
 			<param index="0" name="space" type="RID" />
 			<description>
 				Returns the state of a space, a [PhysicsDirectSpaceState2D]. This object can be used for collision/intersection queries.
+			</description>
+		</method>
+		<method name="space_get_last_process_info" experimental="">
+			<return type="int" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="process_info" type="int" enum="PhysicsServer2D.ProcessInfo" />
+			<description>
+				Returns information about the current state of [param space]. See [enum ProcessInfo] for a list of available states.
 			</description>
 		</method>
 		<method name="space_get_param" qualifiers="const">
@@ -987,6 +1002,15 @@
 			<param index="2" name="value" type="float" />
 			<description>
 				Sets the value of the given space parameter. See [enum SpaceParameter] for the list of available parameters.
+			</description>
+		</method>
+		<method name="space_step" experimental="">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Manually advance [param space] forward in [param delta]. This technique can be used for speeding up physics simulations, as seen in advanced rollback-style networking, or for predicting outcomes in scenarios such as hitting a ball in a billiards game.
+				[b]Note:[/b] If call this method with an active [param space] from [code]_physics_process()[/code], you should call [method space_flush_queries] afterwards. Otherwise, call [method space_flush_queries] beforehand.
 			</description>
 		</method>
 		<method name="world_boundary_shape_create">

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -1024,6 +1024,12 @@
 				Overridable version of [method PhysicsServer2D.space_create].
 			</description>
 		</method>
+		<method name="_space_flush_queries" qualifiers="virtual" experimental="">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_space_get_contact_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="space" type="RID" />
@@ -1045,6 +1051,13 @@
 			<param index="0" name="space" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.space_get_direct_state].
+			</description>
+		</method>
+		<method name="_space_get_last_process_info" qualifiers="virtual" experimental="">
+			<return type="int" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="process_info" type="int" enum="PhysicsServer2D.ProcessInfo" />
+			<description>
 			</description>
 		</method>
 		<method name="_space_get_param" qualifiers="virtual const">
@@ -1086,6 +1099,13 @@
 			<param index="2" name="value" type="float" />
 			<description>
 				Overridable version of [method PhysicsServer2D.space_set_param].
+			</description>
+		</method>
+		<method name="_space_step" qualifiers="virtual" experimental="">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="delta" type="float" />
+			<description>
 			</description>
 		</method>
 		<method name="_step" qualifiers="virtual">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1314,11 +1314,26 @@
 				Creates a space. A space is a collection of parameters for the physics engine that can be assigned to an area or a body. It can be assigned to an area with [method area_set_space], or to a body with [method body_set_space].
 			</description>
 		</method>
+		<method name="space_flush_queries" experimental="">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<description>
+				Flushes [param space]'s queries. It is necessary to call this method after calling [method space_step] with an active space from [code]_physics_process[/code]. Otherwise, call this method before calling [method space_step].
+			</description>
+		</method>
 		<method name="space_get_direct_state">
 			<return type="PhysicsDirectSpaceState3D" />
 			<param index="0" name="space" type="RID" />
 			<description>
 				Returns the state of a space, a [PhysicsDirectSpaceState3D]. This object can be used to make collision/intersection queries.
+			</description>
+		</method>
+		<method name="space_get_last_process_info" experimental="">
+			<return type="int" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="process_info" type="int" enum="PhysicsServer3D.ProcessInfo" />
+			<description>
+				Returns information about the current state of [param space]. See [enum ProcessInfo] for a list of available states.
 			</description>
 		</method>
 		<method name="space_get_param" qualifiers="const">
@@ -1351,6 +1366,15 @@
 			<param index="2" name="value" type="float" />
 			<description>
 				Sets the value for a space parameter. A list of available parameters is on the [enum SpaceParameter] constants.
+			</description>
+		</method>
+		<method name="space_step" experimental="">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Manually advance [param space] forward in [param delta]. This technique can be used for speeding up physics simulations, as seen in advanced rollback-style networking, or for predicting outcomes in scenarios such as hitting a ball in a billiards game.
+				[b]Note:[/b] If call this method with an active [param space] from [code]_physics_process()[/code], you should call [method space_flush_queries] afterwards. Otherwise, call [method space_flush_queries] beforehand.
 			</description>
 		</method>
 		<method name="sphere_shape_create">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1214,6 +1214,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_space_flush_queries" qualifiers="virtual" experimental="">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_space_get_contact_count" qualifiers="virtual const">
 			<return type="int" />
 			<param index="0" name="space" type="RID" />
@@ -1229,6 +1235,13 @@
 		<method name="_space_get_direct_state" qualifiers="virtual">
 			<return type="PhysicsDirectSpaceState3D" />
 			<param index="0" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_get_last_process_info" qualifiers="virtual" experimental="">
+			<return type="int" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="process_info" type="int" enum="PhysicsServer3D.ProcessInfo" />
 			<description>
 			</description>
 		</method>
@@ -1264,6 +1277,13 @@
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SpaceParameter" />
 			<param index="2" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_step" qualifiers="virtual" experimental="">
+			<return type="void" />
+			<param index="0" name="space" type="RID" />
+			<param index="1" name="delta" type="float" />
 			<description>
 			</description>
 		</method>

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -245,6 +245,44 @@ bool GodotPhysicsServer2D::space_is_active(RID p_space) const {
 	return active_spaces.has(space);
 }
 
+void GodotPhysicsServer2D::space_step(RID p_space, real_t p_delta) {
+	GodotSpace2D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+	ERR_FAIL_COND_MSG(active_spaces.has(space), "A activate godot space can't be stepped manually.");
+
+	// May be let pending_shape_update_list as a member of GodotSpaces3D and update shapes by themselves.
+	// To avoid effecting Spaces which are handled by developer (for lockstep/rollback netcode, it is particularly sensitive).
+	// Otherwise, call _update_shapes() directly.
+	SelfList<GodotCollisionObject2D> *collision_object_self = pending_shape_update_list.first();
+	while (collision_object_self) {
+		if (collision_object_self->self()->get_space() == space) {
+			collision_object_self->self()->_shape_changed();
+
+			SelfList<GodotCollisionObject2D> *to_remove = collision_object_self;
+			collision_object_self = collision_object_self->next();
+
+			pending_shape_update_list.remove(to_remove);
+		} else {
+			collision_object_self = collision_object_self->next();
+		}
+	}
+
+	stepper->step(space, p_delta);
+}
+
+void GodotPhysicsServer2D::space_flush_queries(RID p_space) {
+	// Like _update_shapes(), to provide controllability for developers, flushing_queries flag should active as a member of space and check it for each space.
+	// But I'm not sure about that, I am not familiar with multi-threads and the architecture of GodotPhysics.
+	flushing_queries = true;
+
+	GodotSpace2D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+	ERR_FAIL_COND_MSG(active_spaces.has(space), "A activate godot space should not flush queries manually.");
+	space->call_queries();
+
+	flushing_queries = false;
+}
+
 void GodotPhysicsServer2D::space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) {
 	GodotSpace2D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
@@ -1383,6 +1421,25 @@ int GodotPhysicsServer2D::get_process_info(ProcessInfo p_info) {
 		} break;
 		case INFO_ISLAND_COUNT: {
 			return island_count;
+		} break;
+	}
+
+	return 0;
+}
+
+int GodotPhysicsServer2D::space_get_last_process_info(RID p_space, ProcessInfo p_info) {
+	GodotSpace2D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL_V(space, 0);
+
+	switch (p_info) {
+		case INFO_ACTIVE_OBJECTS: {
+			return space->get_active_objects();
+		} break;
+		case INFO_COLLISION_PAIRS: {
+			return space->get_collision_pairs();
+		} break;
+		case INFO_ISLAND_COUNT: {
+			return space->get_island_count();
 		} break;
 	}
 

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -108,6 +108,8 @@ public:
 	virtual RID space_create() override;
 	virtual void space_set_active(RID p_space, bool p_active) override;
 	virtual bool space_is_active(RID p_space) const override;
+	virtual void space_step(RID p_space, real_t p_delta) override;
+	virtual void space_flush_queries(RID p_space) override;
 
 	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) override;
 	virtual real_t space_get_param(RID p_space, SpaceParameter p_param) const override;
@@ -299,6 +301,7 @@ public:
 	virtual bool is_flushing_queries() const override { return flushing_queries; }
 
 	int get_process_info(ProcessInfo p_info) override;
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) override;
 
 	GodotPhysicsServer2D(bool p_using_threads = false);
 	~GodotPhysicsServer2D() {}

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -175,6 +175,44 @@ bool GodotPhysicsServer3D::space_is_active(RID p_space) const {
 	return active_spaces.has(space);
 }
 
+void GodotPhysicsServer3D::space_step(RID p_space, real_t p_delta) {
+	GodotSpace3D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+	ERR_FAIL_COND_MSG(active_spaces.has(space), "A activate godot space can't be stepped manually.");
+
+	// May be let pending_shape_update_list as a member of GodotSpaces3D and update shapes by themselves.
+	// To avoid effecting Spaces which are handled by developer (for lockstep/rollback netcode, it is particularly sensitive).
+	// If it is unnecessary, call _update_shapes() directly.
+	SelfList<GodotCollisionObject3D> *collision_object_self = pending_shape_update_list.first();
+	while (collision_object_self) {
+		if (collision_object_self->self()->get_space() == space) {
+			collision_object_self->self()->_shape_changed();
+
+			SelfList<GodotCollisionObject3D> *to_remove = collision_object_self;
+			collision_object_self = collision_object_self->next();
+
+			pending_shape_update_list.remove(to_remove);
+		} else {
+			collision_object_self = collision_object_self->next();
+		}
+	}
+
+	stepper->step(space, p_delta);
+}
+
+void GodotPhysicsServer3D::space_flush_queries(RID p_space) {
+	// Like _update_shapes(), to provide controllability for developers, flushing_queries flag should active as a member of space and check it for each space.
+	// But I'm not sure about that, I am not familiar with multi-threads and the architecture of GodotPhysics.
+	flushing_queries = true;
+
+	GodotSpace3D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+	ERR_FAIL_COND_MSG(active_spaces.has(space), "A activate godot space should not flush queries manually.");
+	space->call_queries();
+
+	flushing_queries = false;
+}
+
 void GodotPhysicsServer3D::space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) {
 	GodotSpace3D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
@@ -1718,6 +1756,25 @@ int GodotPhysicsServer3D::get_process_info(ProcessInfo p_info) {
 		} break;
 		case INFO_ISLAND_COUNT: {
 			return island_count;
+		} break;
+	}
+
+	return 0;
+}
+
+int GodotPhysicsServer3D::space_get_last_process_info(RID p_space, ProcessInfo p_info) {
+	GodotSpace3D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL_V(space, 0);
+
+	switch (p_info) {
+		case INFO_ACTIVE_OBJECTS: {
+			return space->get_active_objects();
+		} break;
+		case INFO_COLLISION_PAIRS: {
+			return space->get_collision_pairs();
+		} break;
+		case INFO_ISLAND_COUNT: {
+			return space->get_island_count();
 		} break;
 	}
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -106,6 +106,8 @@ public:
 	virtual RID space_create() override;
 	virtual void space_set_active(RID p_space, bool p_active) override;
 	virtual bool space_is_active(RID p_space) const override;
+	virtual void space_step(RID p_space, real_t p_delta) override;
+	virtual void space_flush_queries(RID p_space) override;
 
 	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) override;
 	virtual real_t space_get_param(RID p_space, SpaceParameter p_param) const override;
@@ -377,6 +379,7 @@ public:
 	virtual bool is_flushing_queries() const override { return flushing_queries; }
 
 	int get_process_info(ProcessInfo p_info) override;
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) override;
 
 	GodotPhysicsServer3D(bool p_using_threads = false);
 	~GodotPhysicsServer3D() {}

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -214,6 +214,24 @@ bool JoltPhysicsServer3D::space_is_active(RID p_space) const {
 	return active_spaces.has(space);
 }
 
+void JoltPhysicsServer3D::space_step(RID p_space, real_t p_delta) {
+	JoltSpace3D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+	ERR_FAIL_COND(space->is_stepping());
+
+	space->step(p_delta);
+}
+
+void JoltPhysicsServer3D::space_flush_queries(RID p_space) {
+	flushing_queries = true;
+
+	JoltSpace3D *space = space_owner.get_or_null(p_space);
+	ERR_FAIL_NULL(space);
+	space->call_queries();
+
+	flushing_queries = false;
+}
+
 void JoltPhysicsServer3D::space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) {
 	JoltSpace3D *space = space_owner.get_or_null(p_space);
 	ERR_FAIL_NULL(space);
@@ -1616,6 +1634,10 @@ bool JoltPhysicsServer3D::is_flushing_queries() const {
 }
 
 int JoltPhysicsServer3D::get_process_info(ProcessInfo p_process_info) {
+	return 0;
+}
+
+int JoltPhysicsServer3D::space_get_last_process_info(RID p_space, ProcessInfo p_info) {
 	return 0;
 }
 

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -153,6 +153,8 @@ public:
 
 	virtual void space_set_active(RID p_space, bool p_active) override;
 	virtual bool space_is_active(RID p_space) const override;
+	virtual void space_step(RID p_space, real_t p_delta) override;
+	virtual void space_flush_queries(RID p_space) override;
 
 	virtual void space_set_param(RID p_space, PhysicsServer3D::SpaceParameter p_param, real_t p_value) override;
 	virtual real_t space_get_param(RID p_space, PhysicsServer3D::SpaceParameter p_param) const override;
@@ -420,6 +422,7 @@ public:
 	virtual bool is_flushing_queries() const override;
 
 	virtual int get_process_info(PhysicsServer3D::ProcessInfo p_process_info) override;
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) override;
 
 	bool is_active() const { return active; }
 

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -151,6 +151,8 @@ void PhysicsServer2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_space_create);
 	GDVIRTUAL_BIND(_space_set_active, "space", "active");
 	GDVIRTUAL_BIND(_space_is_active, "space");
+	GDVIRTUAL_BIND(_space_step, "space", "delta")
+	GDVIRTUAL_BIND(_space_flush_queries, "space")
 
 	GDVIRTUAL_BIND(_space_set_param, "space", "param", "value");
 	GDVIRTUAL_BIND(_space_get_param, "space", "param");
@@ -342,6 +344,7 @@ void PhysicsServer2DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_is_flushing_queries);
 	GDVIRTUAL_BIND(_get_process_info, "process_info");
+	GDVIRTUAL_BIND(_space_get_last_process_info, "space", "process_info");
 }
 
 PhysicsServer2DExtension::PhysicsServer2DExtension() {

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -226,6 +226,8 @@ public:
 	EXBIND0R(RID, space_create)
 	EXBIND2(space_set_active, RID, bool)
 	EXBIND1RC(bool, space_is_active, RID)
+	EXBIND2(space_step, RID, real_t)
+	EXBIND1(space_flush_queries, RID)
 
 	EXBIND3(space_set_param, RID, SpaceParameter, real_t)
 	EXBIND2RC(real_t, space_get_param, RID, SpaceParameter)
@@ -447,6 +449,7 @@ public:
 
 	EXBIND0RC(bool, is_flushing_queries)
 	EXBIND1R(int, get_process_info, ProcessInfo)
+	EXBIND2R(int, space_get_last_process_info, RID, ProcessInfo)
 
 	PhysicsServer2DExtension();
 	~PhysicsServer2DExtension();

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -157,6 +157,8 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_space_create);
 	GDVIRTUAL_BIND(_space_set_active, "space", "active");
 	GDVIRTUAL_BIND(_space_is_active, "space");
+	GDVIRTUAL_BIND(_space_step, "space", "delta")
+	GDVIRTUAL_BIND(_space_flush_queries, "space")
 
 	GDVIRTUAL_BIND(_space_set_param, "space", "param", "value");
 	GDVIRTUAL_BIND(_space_get_param, "space", "param");
@@ -422,6 +424,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_is_flushing_queries);
 	GDVIRTUAL_BIND(_get_process_info, "process_info");
+	GDVIRTUAL_BIND(_space_get_last_process_info, "space", "process_info");
 }
 
 PhysicsServer3DExtension::PhysicsServer3DExtension() {

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -232,6 +232,8 @@ public:
 	EXBIND0R(RID, space_create)
 	EXBIND2(space_set_active, RID, bool)
 	EXBIND1RC(bool, space_is_active, RID)
+	EXBIND2(space_step, RID, real_t)
+	EXBIND1(space_flush_queries, RID)
 
 	EXBIND3(space_set_param, RID, SpaceParameter, real_t)
 	EXBIND2RC(real_t, space_get_param, RID, SpaceParameter)
@@ -535,6 +537,7 @@ public:
 
 	EXBIND0RC(bool, is_flushing_queries)
 	EXBIND1R(int, get_process_info, ProcessInfo)
+	EXBIND2R(int, space_get_last_process_info, RID, ProcessInfo)
 
 	PhysicsServer3DExtension();
 	~PhysicsServer3DExtension();

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -634,6 +634,8 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("space_create"), &PhysicsServer2D::space_create);
 	ClassDB::bind_method(D_METHOD("space_set_active", "space", "active"), &PhysicsServer2D::space_set_active);
 	ClassDB::bind_method(D_METHOD("space_is_active", "space"), &PhysicsServer2D::space_is_active);
+	ClassDB::bind_method(D_METHOD("space_step", "space", "delta"), &PhysicsServer2D::space_step);
+	ClassDB::bind_method(D_METHOD("space_flush_queries", "space"), &PhysicsServer2D::space_flush_queries);
 	ClassDB::bind_method(D_METHOD("space_set_param", "space", "param", "value"), &PhysicsServer2D::space_set_param);
 	ClassDB::bind_method(D_METHOD("space_get_param", "space", "param"), &PhysicsServer2D::space_get_param);
 	ClassDB::bind_method(D_METHOD("space_get_direct_state", "space"), &PhysicsServer2D::space_get_direct_state);
@@ -793,6 +795,7 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &PhysicsServer2D::set_active);
 
 	ClassDB::bind_method(D_METHOD("get_process_info", "process_info"), &PhysicsServer2D::get_process_info);
+	ClassDB::bind_method(D_METHOD("space_get_last_process_info", "space", "process_info"), &PhysicsServer2D::space_get_last_process_info);
 
 	BIND_ENUM_CONSTANT(SPACE_PARAM_CONTACT_RECYCLE_RADIUS);
 	BIND_ENUM_CONSTANT(SPACE_PARAM_CONTACT_MAX_SEPARATION);

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -253,6 +253,8 @@ public:
 	virtual RID space_create() = 0;
 	virtual void space_set_active(RID p_space, bool p_active) = 0;
 	virtual bool space_is_active(RID p_space) const = 0;
+	virtual void space_step(RID p_space, real_t p_delta) = 0;
+	virtual void space_flush_queries(RID p_space) = 0;
 
 	enum SpaceParameter {
 		SPACE_PARAM_CONTACT_RECYCLE_RADIUS,
@@ -608,6 +610,7 @@ public:
 	};
 
 	virtual int get_process_info(ProcessInfo p_info) = 0;
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) = 0;
 
 	PhysicsServer2D();
 	~PhysicsServer2D();

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -149,6 +149,8 @@ public:
 	virtual RID space_create() override { return RID(); }
 	virtual void space_set_active(RID p_space, bool p_active) override {}
 	virtual bool space_is_active(RID p_space) const override { return false; }
+	virtual void space_step(RID p_space, real_t p_delta) override {}
+	virtual void space_flush_queries(RID p_space) override {}
 
 	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) override {}
 	virtual real_t space_get_param(RID p_space, SpaceParameter p_param) const override { return 0; }
@@ -345,6 +347,7 @@ public:
 	virtual bool is_flushing_queries() const override { return false; }
 
 	virtual int get_process_info(ProcessInfo p_info) override { return 0; }
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) override { return 0; }
 };
 
 #endif // PHYSICS_SERVER_2D_DUMMY_H

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -100,6 +100,8 @@ public:
 	FUNCRID(space);
 	FUNC2(space_set_active, RID, bool);
 	FUNC1RC(bool, space_is_active, RID);
+	FUNC2(space_step, RID, real_t);
+	FUNC1(space_flush_queries, RID);
 
 	FUNC3(space_set_param, RID, SpaceParameter, real_t);
 	FUNC2RC(real_t, space_get_param, RID, SpaceParameter);
@@ -317,8 +319,12 @@ public:
 		return physics_server_2d->is_flushing_queries();
 	}
 
-	int get_process_info(ProcessInfo p_info) override {
+	virtual int get_process_info(ProcessInfo p_info) override {
 		return physics_server_2d->get_process_info(p_info);
+	}
+
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) override {
+		return physics_server_2d->space_get_last_process_info(p_space, p_info);
 	}
 
 	PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool p_create_thread);

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -712,6 +712,8 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("space_create"), &PhysicsServer3D::space_create);
 	ClassDB::bind_method(D_METHOD("space_set_active", "space", "active"), &PhysicsServer3D::space_set_active);
 	ClassDB::bind_method(D_METHOD("space_is_active", "space"), &PhysicsServer3D::space_is_active);
+	ClassDB::bind_method(D_METHOD("space_step", "space", "delta"), &PhysicsServer3D::space_step);
+	ClassDB::bind_method(D_METHOD("space_flush_queries", "space"), &PhysicsServer3D::space_flush_queries);
 	ClassDB::bind_method(D_METHOD("space_set_param", "space", "param", "value"), &PhysicsServer3D::space_set_param);
 	ClassDB::bind_method(D_METHOD("space_get_param", "space", "param"), &PhysicsServer3D::space_get_param);
 	ClassDB::bind_method(D_METHOD("space_get_direct_state", "space"), &PhysicsServer3D::space_get_direct_state);
@@ -1034,6 +1036,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &PhysicsServer3D::set_active);
 
 	ClassDB::bind_method(D_METHOD("get_process_info", "process_info"), &PhysicsServer3D::get_process_info);
+	ClassDB::bind_method(D_METHOD("space_get_last_process_info", "space", "process_info"), &PhysicsServer3D::space_get_last_process_info);
 
 	BIND_ENUM_CONSTANT(SHAPE_WORLD_BOUNDARY);
 	BIND_ENUM_CONSTANT(SHAPE_SEPARATION_RAY);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -284,6 +284,8 @@ public:
 	virtual RID space_create() = 0;
 	virtual void space_set_active(RID p_space, bool p_active) = 0;
 	virtual bool space_is_active(RID p_space) const = 0;
+	virtual void space_step(RID p_space, real_t p_delta) = 0;
+	virtual void space_flush_queries(RID p_space) = 0;
 
 	enum SpaceParameter {
 		SPACE_PARAM_CONTACT_RECYCLE_RADIUS,
@@ -809,6 +811,7 @@ public:
 	};
 
 	virtual int get_process_info(ProcessInfo p_info) = 0;
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) = 0;
 
 	PhysicsServer3D();
 	~PhysicsServer3D();

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -157,6 +157,8 @@ public:
 	virtual RID space_create() override { return RID(); }
 	virtual void space_set_active(RID p_space, bool p_active) override {}
 	virtual bool space_is_active(RID p_space) const override { return false; }
+	virtual void space_step(RID p_space, real_t p_delta) override {}
+	virtual void space_flush_queries(RID p_space) override {}
 
 	virtual void space_set_param(RID p_space, SpaceParameter p_param, real_t p_value) override {}
 	virtual real_t space_get_param(RID p_space, SpaceParameter p_param) const override { return 0; }
@@ -431,6 +433,7 @@ public:
 	virtual bool is_flushing_queries() const override { return false; }
 
 	virtual int get_process_info(ProcessInfo p_info) override { return 0; }
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) override { return 0; }
 };
 
 #endif // PHYSICS_SERVER_3D_DUMMY_H

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -107,6 +107,8 @@ public:
 	FUNCRID(space);
 	FUNC2(space_set_active, RID, bool);
 	FUNC1RC(bool, space_is_active, RID);
+	FUNC2(space_step, RID, real_t);
+	FUNC1(space_flush_queries, RID);
 
 	FUNC3(space_set_param, RID, SpaceParameter, real_t);
 	FUNC2RC(real_t, space_get_param, RID, SpaceParameter);
@@ -393,8 +395,12 @@ public:
 		return physics_server_3d->is_flushing_queries();
 	}
 
-	int get_process_info(ProcessInfo p_info) override {
+	virtual int get_process_info(ProcessInfo p_info) override {
 		return physics_server_3d->get_process_info(p_info);
+	}
+
+	virtual int space_get_last_process_info(RID p_space, ProcessInfo p_info) override {
+		return physics_server_3d->space_get_last_process_info(p_space, p_info);
 	}
 
 	PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread);


### PR DESCRIPTION
merge Daylily-Zeleen's work to allow us to manually tick the physics server, which is necessary for predicting rigidbodys
